### PR TITLE
Fix parameter name in dump_to_file docstring

### DIFF
--- a/stealer_parser/helpers.py
+++ b/stealer_parser/helpers.py
@@ -33,7 +33,7 @@ def dump_to_file(
     ----------
     logger : verboselogs.VerboseLogger
         The program's logger.
-    filebame : str
+    filename : str
         The file to write to.
     content : str or Any
         The data to write.


### PR DESCRIPTION
## Summary
- fix a typo in `dump_to_file` docstring

## Testing
- `pre-commit run --files stealer_parser/helpers.py` *(fails: missing Python3.10 interpreter)*

------
https://chatgpt.com/codex/tasks/task_e_68528618b0f88332bdf36d9d455394b9